### PR TITLE
feat: enhance visuals and add ambience

### DIFF
--- a/style.css
+++ b/style.css
@@ -35,6 +35,7 @@ canvas#game{position:absolute;inset:0;display:block;margin:auto;max-width:100%;m
 .rail{position:absolute;top:0;right:0;width:150px;height:100%;background:rgba(10,13,22,.65);border-left:1px solid rgba(255,255,255,.06);backdrop-filter:blur(4px);pointer-events:auto}
 .rail .entry{display:flex;align-items:center;gap:8px;padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.04)}
 .rail .portrait{width:40px;height:40px;border-radius:8px;flex:0 0 auto;border:2px solid rgba(255,255,255,.15);background:#111}
+.rail .portrait img{width:100%;height:100%;border-radius:6px;display:block}
 .rail .meta{display:flex;flex-direction:column;gap:2px}
 .rail .name{font-weight:700}
 .rail .ct{font-size:12px;color:var(--muted)}


### PR DESCRIPTION
## Summary
- Add lo-fi Holst-inspired soundtrack, rain, lightning, stained glass windows, and chandeliers to the battlefield
- Enlarge character faces and portraits, placing heads above bodies and filling the turn-order rail
- Animate projectiles with hit/miss popups and pace red-team AI turns with a two-second delay while ignoring player input

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68965ff9ab2083269fb6ce84180c7c07