### PR TITLE
Improve turn flow and movement handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
       <div id="statusPanel"></div>
       <div id="inspectPanel"></div>
       <div id="toast"></div>
+      <div id="stateIndicator"></div>
     </div>
   </div>
   <script src="main.js"></script>

--- a/style.css
+++ b/style.css
@@ -32,6 +32,7 @@ canvas#game{position:absolute;inset:0;display:block;margin:auto;max-width:100%;m
 #inspectPanel .line{display:flex;justify-content:space-between;gap:12px;margin:4px 0}
 
 #toast{position:absolute;left:0;right:0;top:12px;text-align:center;font-weight:600;color:#fff;text-shadow:0 2px 8px rgba(0,0,0,.6);pointer-events:none}
+#stateIndicator{position:absolute;left:0;right:0;bottom:140px;text-align:center;font-weight:600;color:#fff;text-shadow:0 2px 8px rgba(0,0,0,.6);pointer-events:none;opacity:0;transition:opacity .2s}
 
 /* Turn order rail */
 .rail{position:absolute;top:0;right:0;width:150px;height:100%;background:rgba(10,13,22,.65);border-left:1px solid rgba(255,255,255,.06);backdrop-filter:blur(4px);pointer-events:auto}


### PR DESCRIPTION
## Summary
- add UI state indicator so players know when the game is idle, animating, or waiting for commands
- guard input and move selection to prevent acting outside of a turn and stop multiple moves per turn
- refine movement animation logic for smoother, consistent transitions

## Testing
- `node --check main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966764e2808326984139f4ce381e21